### PR TITLE
Fix an issue that crashed the app when clicking on a complete trip

### DIFF
--- a/app/views/trips/_buddies-card.html.erb
+++ b/app/views/trips/_buddies-card.html.erb
@@ -12,7 +12,7 @@
       <div class="buddies__card__info">
 
         <h3 class="buddies__card__name">
-          <%= @user.first_name.capitalize %> <%= @user.last_name.capitalize[0] %>
+          <%= @user.first_name&.capitalize %> <%= @user.last_name&.capitalize[0] %>
         </h3>
 
         <div class="buddies__card__rating">


### PR DESCRIPTION
Added `&` before `.capitalize` to prevent app to crash when clicking on a complete trip